### PR TITLE
fix: export CyclePlugin, so it can be referenced and disabled

### DIFF
--- a/source/index.ts
+++ b/source/index.ts
@@ -13,6 +13,7 @@ export { inferPath, inferType } from "./util";
 import { hide, tag } from "./operators";
 
 import {
+    CyclePlugin,
     DebugPlugin,
     DevToolsPlugin,
     GraphPlugin,
@@ -25,6 +26,7 @@ import {
 } from "./plugin";
 
 export const plugins = {
+    CyclePlugin,
     DebugPlugin,
     DevToolsPlugin,
     GraphPlugin,


### PR DESCRIPTION
Hi @cartant. Thank you for wonderful tool. It's invaluable for us.

Noticed that disabling `CyclePlugin` is not quite possible because it is not re-exported. This little PR is to fix that.