### PR TITLE
2.0.7 of error-stack-parser removed an exported interface

### DIFF
--- a/source/plugin/snapshot-plugin.ts
+++ b/source/plugin/snapshot-plugin.ts
@@ -3,7 +3,7 @@
  * can be found in the LICENSE file at https://github.com/cartant/rxjs-spy
  */
 
-import { StackFrame } from "error-stack-parser";
+import * as StackFrame from "stackframe";
 import { forkJoin, Observable, of, Subscriber, Subscription } from "rxjs";
 import { mapTo } from "rxjs/operators";
 import { identify } from "../identify";

--- a/source/plugin/stack-trace-plugin.ts
+++ b/source/plugin/stack-trace-plugin.ts
@@ -4,7 +4,8 @@
  */
 /*tslint:disable:rxjs-no-sharereplay*/
 
-import { parse, StackFrame } from "error-stack-parser";
+import * as StackFrame from "stackframe";
+import { parse } from "error-stack-parser";
 import { defer, Observable, of } from "rxjs";
 import { shareReplay } from "rxjs/operators";
 


### PR DESCRIPTION
Fixes #61

this commit in stacktracejs broke types for dependencies including this package: https://github.com/stacktracejs/error-stack-parser/commit/ce729eeeeb33d0e47927000b8aa544196abe3f9c