### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ create();
 The `tag` operator can be used with `pipe`:
 
 ```js
-import { tag } from "rxjs-spy/operators/tag";
+import { tag } from "rxjs-spy/operators";
 const source = Observable.of("some-value").pipe(tag("some-tag"));
 ```
 


### PR DESCRIPTION
When I tried to import `rxjs-spy/operators/tag` I got this error:

```
Module not found: Error: Package path ./operators/tag is not exported from package /Users/oliverash/Development/unsplash/unsplash-web/node_modules/rxjs-spy (see exports field in /Users/oliverash/Development/unsplash/unsplash-web/node_modules/rxjs-spy/package.json)
```

It seems we need to import from `rxjs-spy/operators` instead:

https://github.com/cartant/rxjs-spy/blob/f5f459170a977701d0cecb52ac2679853d6050df/package.json#L63